### PR TITLE
feat: expose the lang.Scope type.

### DIFF
--- a/internal/tfdiags/rpc_friendly.go
+++ b/internal/tfdiags/rpc_friendly.go
@@ -1,3 +1,5 @@
+// Copyright (c) Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
 // Copyright (c) The OpenTofu Authors
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2023 HashiCorp, Inc.
@@ -65,5 +67,5 @@ func (d rpcFriendlyDiag) ExtraInfo() interface{} {
 }
 
 func init() {
-	gob.Register((*rpcFriendlyDiag)(nil))
+	gob.RegisterName("tfdiags.rpcFriendlyDiag", (*rpcFriendlyDiag)(nil))
 }

--- a/lang/public.go
+++ b/lang/public.go
@@ -1,3 +1,6 @@
+// Copyright (c) Terramate GmbH
+// SPDX-License-Identifier: MPL-2.0
+
 package lang
 
 import "github.com/terramate-io/opentofulib/internal/lang"

--- a/lang/public.go
+++ b/lang/public.go
@@ -1,0 +1,6 @@
+package lang
+
+import "github.com/terramate-io/opentofulib/internal/lang"
+
+// Scope is an alias for the internal lang.Scope.
+type Scope = lang.Scope


### PR DESCRIPTION
Expose the `lang.Scope` type for manipulating Tofu functions.