### PR TITLE
chore: remove installation checks.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -222,14 +222,3 @@ jobs:
         with:
           path: ".licensei.cache"
           key: licensei-cache-${{ hashFiles('go.sum') }}
- 
-  installation-instructions:
-    name: "Test Installation Instructions"
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: "Fetch source code"
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-
-      - name: "Run Installation Instructions Test"
-        run: make test-linux-install-instructions


### PR DESCRIPTION
This fork does not distribute binaries, then this check can be removed.

They were failing for opensuse, probably because lacking of secrets.